### PR TITLE
docs(adr): add ADR scaffolding (index + template)

### DIFF
--- a/adrs/decisions/0000-template.md
+++ b/adrs/decisions/0000-template.md
@@ -1,0 +1,31 @@
+# NNNN. Short title of the decision
+
+- Status: Proposed | Accepted | Superseded by [NNNN](NNNN-....md)
+- Date: YYYY-MM-DD
+
+## Context and problem statement
+
+What is the situation? What forces are at play? State the problem in a couple of
+sentences, ideally as a question we are answering.
+
+## Decision drivers
+
+- driver 1 (e.g. a concern, a constraint, a goal)
+- driver 2
+
+## Considered options
+
+- option 1
+- option 2
+
+## Decision outcome
+
+What did we decide, and why? Stay at the level of the decision and its rationale —
+keep concrete values (subnets, IDs, ports, labels, tunables) in the issues and
+config, not here.
+
+### Consequences
+
+- Good — ...
+- Bad — ...
+- Note / follow-up — ...

--- a/adrs/decisions/README.md
+++ b/adrs/decisions/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+Significant architecture decisions for the homelab, recorded in the
+[MADR](https://adr.github.io/madr/) format.
+
+## Why
+
+Decisions made during design tend to evaporate, leaving only the *what* and not
+the *why*. ADRs capture the context and rationale so future contributors (and
+future us) can understand why things are the way they are — and revisit them
+deliberately rather than by accident.
+
+ADRs record **decisions, not implementation detail**. Concrete values (subnets,
+IDs, ports, labels, tunables) live in the tracking issues and the resulting
+Terraform / Ansible / RouterOS config, not here, so an ADR stays valid even as the
+implementation changes.
+
+## Process
+
+1. Copy `0000-template.md` to `NNNN-short-title.md` using the next free number.
+2. Draft with status **Proposed**.
+3. Once agreed, change status to **Accepted**.
+4. Never delete an ADR. If a decision changes, write a new ADR and mark the old
+   one **Superseded by [NNNN](...)**.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-network-and-connectivity.md) | Network and connectivity architecture | Accepted |
+| [0002](0002-compute-and-workload-placement.md) | Compute and workload placement | Accepted |
+| [0003](0003-infrastructure-automation-and-delivery.md) | Infrastructure automation and delivery | Accepted |


### PR DESCRIPTION
Sets up `adrs/decisions/` for recording architecture decisions in the
[MADR](https://adr.github.io/madr/) format.

- `README.md` — purpose, process, and the decision index
- `0000-template.md` — template for new ADRs

ADRs record **decisions, not implementation detail**; concrete values live in
issues and config. Individual decisions follow in separate PRs (0001–0003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)