### PR TITLE
docs(adr): 0006 trust tiers and workload exposure placement

### DIFF
--- a/adrs/decisions/0001-network-and-connectivity.md
+++ b/adrs/decisions/0001-network-and-connectivity.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-06-11
+- Refined by [0006](0006-trust-tiers-and-workload-exposure-placement.md) (2026-06-30) — adds a `services` trust tier distinct from mgmt.
 
 ## Context and problem statement
 

--- a/adrs/decisions/0002-compute-and-workload-placement.md
+++ b/adrs/decisions/0002-compute-and-workload-placement.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-06-11
+- Refined by [0006](0006-trust-tiers-and-workload-exposure-placement.md) (2026-06-30) — public-facing workloads move to the cloud cluster; the home DMZ/public pool is deferred.
 
 ## Context and problem statement
 

--- a/adrs/decisions/0006-trust-tiers-and-workload-exposure-placement.md
+++ b/adrs/decisions/0006-trust-tiers-and-workload-exposure-placement.md
@@ -1,0 +1,72 @@
+# 0006. Trust tiers and workload exposure placement
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context and problem statement
+
+ADR [0001](0001-network-and-connectivity.md) segments the LAN into trust zones;
+ADR [0002](0002-compute-and-workload-placement.md) places workloads. Operating the
+lab surfaced two gaps. First, self-hosted services (Home Assistant) had no zone of
+their own and ended up in **management** — the most-privileged zone — giving a fat,
+integration-heavy appliance a path to the router and hypervisor if it were ever
+compromised. Second, "where does a workload go?" was being answered by what a
+workload *is* (server, appliance, IoT) rather than by its **internet exposure**,
+which is what actually drives blast radius. How should we tier trust and place
+workloads so that a compromise stays contained?
+
+## Decision drivers
+
+- Contain blast radius — a compromised, internet-exposed, or integration-heavy
+  workload must not reach infra (mgmt) or user devices (trusted).
+- Keep the zone count to segments that each carry a **distinct, maintained policy**;
+  a VLAN nobody can write a durable rule for is sprawl, and a misconfigured rule is
+  itself a risk.
+- Client-facing services should stay up independently of the home WAN.
+- Stay simple and hand-operable — refine the live design in place, do not redesign.
+
+## Considered options
+
+- Service placement: leave services in `mgmt` vs. a dedicated `services` tier vs.
+  fold them into `trusted`.
+- Segmentation axis: by **role** (server / appliance / IoT) vs. by **internet
+  exposure**.
+- Public-facing workloads: a home DMZ/public pool (per ADR 0002) vs. exile to the
+  existing cloud cluster.
+- Home Assistant (a VM) + private k3s: separate tiers vs. co-located in `services`.
+
+## Decision outcome
+
+- **Introduce a `services` trust tier, distinct from `mgmt`.** Self-hosted apps
+  (Home Assistant, private k3s and the addresses it exposes) live there; `mgmt`
+  returns to infra-only. `services` may reach IoT/NoT to control devices and the
+  internet for updates, but **not** `mgmt` or `trusted` — one-way trust.
+- **Segment and place by internet exposure, not by role.** Exposure is the axis
+  that drives blast radius, so it is the axis we segment on.
+- **Public-facing workloads run in the cloud** (the existing Hetzner cluster), not
+  at home — so the home network stays zero-public and client-facing uptime does not
+  depend on the home WAN. ADR 0002's home DMZ/public pool is **deferred** until
+  there is a real reason to host public services at home.
+- **Home Assistant and private k3s co-locate in `services`** (a single VLAN). With
+  the exposed tier no longer at home, there is nothing untrusted for HAOS to share a
+  broadcast domain with; the k3s nodes are hardened host-side (API/kubelet
+  restricted to the cluster) as defence in depth.
+- The **active trust tiers are `mgmt`, `trusted`, `services`, `iot`, `not`,
+  `guest`** (six), with **`lab` and `travel` defined but dormant** until populated.
+  `NoT` (internet-denied) stays a VLAN rather than a per-device rule — the VLAN is
+  the scalable, default-contained policy boundary.
+
+### Consequences
+
+- Good — a compromised Home Assistant or home workload cannot pivot to the router,
+  hypervisor, or laptops; internet exposure is off the home network entirely; the
+  zone set maps one-to-one to policies we actually maintain.
+- Bad — cross-VLAN device discovery now needs an mDNS reflector between `services`
+  and IoT/NoT; public hosting depends on the cloud cluster; ADR 0002's home public
+  pool is shelved rather than built.
+- Note / follow-up — this **refines** ADR [0001](0001-network-and-connectivity.md)
+  (adds the `services` tier) and ADR
+  [0002](0002-compute-and-workload-placement.md) (public → cloud; home pool
+  deferred); neither is fully superseded. Concrete VLAN IDs, subnets, the trust
+  matrix, and the Proxmox trunk change live in the tracking issues and the resulting
+  RouterOS / Proxmox config, not here.

--- a/adrs/decisions/README.md
+++ b/adrs/decisions/README.md
@@ -30,3 +30,4 @@ implementation changes.
 | [0001](0001-network-and-connectivity.md) | Network and connectivity architecture | Accepted |
 | [0002](0002-compute-and-workload-placement.md) | Compute and workload placement | Accepted |
 | [0003](0003-infrastructure-automation-and-delivery.md) | Infrastructure automation and delivery | Accepted |
+| [0006](0006-trust-tiers-and-workload-exposure-placement.md) | Trust tiers and workload exposure placement | Accepted |


### PR DESCRIPTION
## What

New **ADR 0006 — Trust tiers and workload exposure placement**, plus its README index row.

Captures the decisions from the network/compute replanning session, at decision-level (concrete VLAN IDs / subnets / matrix stay in the tracking issues, per the house style):

- Introduce a **`services` trust tier distinct from `mgmt`** — Home Assistant + private k3s live there; `mgmt` returns to infra-only. One-way trust (services → IoT/NoT + internet, never → mgmt/trusted).
- **Segment and place by internet exposure, not by role.**
- **Public-facing workloads → cloud (Hetzner)**, not a home pool — home stays zero-public; client-facing uptime no longer hostage to the home WAN. ADR 0002's home DMZ/public pool is **deferred**.
- **HAOS + private k3s co-locate in `services`** (the exposed tier is no longer at home), k3s nodes hardened host-side as defence in depth.
- Active tiers: **mgmt, trusted, services, iot, not, guest** (six); **lab + travel dormant**. NoT stays a VLAN, not a per-device rule.

## Why

Operating the lab put Home Assistant in `mgmt` (the crown-jewels zone) for lack of a home of its own, and "placement by role" didn't track blast radius. Cross-checked against TechnoTim (minimalist, exposed compute exiled to colo) and Mateusz Chrobok (security-first, keeps IoT/NoT split) — both converge on this shape.

## Convention notes

- Follows the "new ADR for a changed decision, never edit-in-place" rule. **0006** is used (not 0004/0005) to avoid clobbering the numbers reserved by #164 (identity) and #169 (security monitoring).
- 0001 and 0002 are **refined, not superseded** — 0006 references them from its Consequences; their status is left unchanged. If you'd prefer explicit back-pointers added to 0001/0002, say so (that'd introduce a "Refined by" line, a small new convention).

## Follow-up issues (specifics)

- Canonical VLAN/zone map + trust matrix
- Make Proxmox VLAN-aware (ether3 all-tagged trunk + vmbr0 subinterfaces)
- Resolve ADR 0003 GitOps engine (ArgoCD vs Flux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)