### PR TITLE
chore: add Claude Code config and repo working agreement

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in *.tf|*.tofu) tofu fmt \"$f\";; esac; } 2>/dev/null || true",
+            "statusMessage": "tofu fmt"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/iac-check/SKILL.md
+++ b/.claude/skills/iac-check/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: iac-check
+description: Run local OpenTofu validation (fmt-check, validate, plan) against terraform/environments/prod for pre-PR feedback. Use before opening an IaC PR or to check a Terraform change locally.
+---
+
+# Local IaC check
+
+Give fast local feedback on Terraform/OpenTofu changes, mirroring what CI gates. Run from `terraform/environments/prod/` (the OpenTofu root). If that directory doesn't exist yet, the tree hasn't been rebuilt — say so and stop.
+
+## Steps
+
+1. `tofu fmt -check -recursive` — report any unformatted files (fix with `tofu fmt` only if the owner asks).
+2. `tofu init -input=false` if `.terraform/` is absent or providers changed.
+3. `tofu validate`.
+4. `tofu plan -input=false -lock-timeout=300s` — summarize the diff (creates/updates/destroys). Flag any destroy or replace.
+5. If `tflint` is installed, run `tflint --init` then `tflint`. It's CI-only here, so note if it's missing rather than treating that as a failure.
+
+This needs cloud/state credentials (GCS backend, Hetzner/Cloudflare). If `init`/`plan` fails on auth, report it plainly — don't try to fabricate credentials. Never run `apply`.

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: new-adr
+description: Scaffold a new MADR architecture decision record in adrs/decisions/. Use when the owner wants to record a new architectural decision. Picks the next free number, starts as Proposed, keeps it decision-level.
+disable-model-invocation: true
+---
+
+# Scaffold a new ADR
+
+Create a new MADR (adr.github.io/madr) decision record. Title/topic comes from `$ARGUMENTS`.
+
+## Steps
+
+1. Ensure `adrs/decisions/` exists. If `adrs/decisions/0000-template.md` is missing, the tree hasn't been rebuilt yet — tell the owner and ask before creating a template from scratch.
+2. Find the next free 4-digit number: list `adrs/decisions/NNNN-*.md`, take `max + 1` (zero-padded, e.g. `0004`). Gaps are fine — never reuse or renumber existing ADRs.
+3. Copy `0000-template.md` to `adrs/decisions/NNNN-<short-kebab-title>.md`. Fill in: title, **Status: Proposed**, today's date, and the Context/problem statement from `$ARGUMENTS`. Leave decision drivers, considered options, outcome, and consequences as prompts for the owner to complete.
+4. Keep it **decision-level, not detailed** — concrete values (subnets, IDs, ports) go in the tracking issue/config, not the ADR. Reference the related issue / Project #14 item if known.
+5. Do **not** commit. Remind the owner: one ADR per PR, branch first, `docs(adr):` commit scope.
+
+Report the new file path and the number chosen.

--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,5 @@ terraform.rc
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/git,terraform,visualstudiocode,python,ansible
+# Claude Code personal notes
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+Personal homelab infrastructure-as-code. The working tree was deliberately reset (`A new start`) and is being rebuilt; most structure below currently lives in git history and is being reintroduced. Intended stack:
+
+- **OpenTofu** (`tofu`, not the `terraform` CLI) — state in a GCS backend (`malachowski-state`, prefix `prod`). `required_version >= 1.3.0`.
+- **Packer** — builds openSUSE MicroOS + k3s snapshots on Hetzner Cloud.
+- **Ansible** — node OS baseline and RouterOS (`community.routeros`).
+- **Flux** — GitOps in-cluster delivery (chosen over ArgoCD, see ADR 0003).
+- **k3s** on Hetzner Cloud; **Cloudflare** for DNS/edge. Secrets live in **GCP Secret Manager**.
+
+Intended top-level layout (referenced by `.github/labeler.yml`): `terraform/environments/prod/`, `terraform/modules/`, `packer/`, `ansible/`, `adrs/decisions/`.
+
+## Commands
+
+A `Makefile` wraps the commands CI runs (`make help` lists them). Key targets: `make plan`, `make check` (fmt-check + validate + tflint), `make apply`, `make drift`, `make lint-ansible`, `make snapshot`. Override dirs via `TF_DIR`/`PKR_DIR`/`ANSIBLE_DIR`.
+
+Underlying commands, if run by hand:
+
+- `tofu init -input=false` / `tofu validate` / `tofu plan -input=false -lock-timeout=300s` / `tofu apply -auto-approve -lock-timeout=300s` — run inside `terraform/environments/prod/` (or `tofu -chdir=...`).
+- Drift check: `tofu plan -detailed-exitcode`.
+- `tflint --init` then `tflint`. Lint Ansible with `ansible-lint`.
+- `packer init .` then `packer build -var "name_suffix=..."` inside `packer/<snapshot>/`.
+
+## Workflow conventions
+
+- **Everything lands via a PR.** No direct commits to `main` — branch first, let CI gate it. This applies to IaC, manifests, docs, and ADRs alike.
+- **Never commit without an explicit order** from the owner.
+- **Conventional Commits** with semantic scopes: `docs(adr):`, `chore(deps):`, `feat:`, `fix:`, `refactor:`.
+- **Working-first, then codify**: get a change working by hand (CLI/Winbox) first, then capture it as self-deploying code with the *why* in the commit message. A dead config export committed just to have it in git is not codification.
+- Secrets stay out of the repo (GCP Secret Manager, GitHub Actions secrets) — never suggest committing them.
+- Renovate manages dependency bumps (minor/patch/digest + github-actions auto-merge; majors gated).
+
+## ADRs
+
+Format is **MADR** (adr.github.io/madr), stored in `adrs/decisions/`. Copy `0000-template.md` to `NNNN-short-title.md` (next free number), start as Proposed, then Accepted. Never delete an ADR — supersede it with a new one. Keep ADRs **decision-level, not detailed**: concrete values (subnets, IDs, ports) belong in tracking issues/config, not the ADR. One ADR per PR. Use `/new-adr` to scaffold.


### PR DESCRIPTION
## What

Restores the repo working agreement and adds Claude Code project config after the `A new start` reset.

- **`CLAUDE.md`** — working agreement + stack/commands/conventions (OpenTofu, Packer, Ansible, Flux/k3s, MADR ADRs, PR-only, Conventional Commits).
- **`.claude/settings.json`** — `PostToolUse` hook running `tofu fmt` on edited `*.tf` files.
- **`.claude/skills/new-adr`** — scaffold the next MADR ADR.
- **`.claude/skills/iac-check`** — local `tofu fmt`/`validate`/`plan`.
- **`.gitignore`** — ignore the personal `CLAUDE.local.md`.

## Notes

`CLAUDE.md` references the Makefile and ADR template that land in sibling PRs; merge those to resolve the references.
