### PR TITLE
docs(adr): restore ADR template scaffolding

### DIFF
--- a/adrs/decisions/0000-template.md
+++ b/adrs/decisions/0000-template.md
@@ -1,0 +1,31 @@
+# NNNN. Short title of the decision
+
+- Status: Proposed | Accepted | Superseded by [NNNN](NNNN-....md)
+- Date: YYYY-MM-DD
+
+## Context and problem statement
+
+What is the situation? What forces are at play? State the problem in a couple of
+sentences, ideally as a question we are answering.
+
+## Decision drivers
+
+- driver 1 (e.g. a concern, a constraint, a goal)
+- driver 2
+
+## Considered options
+
+- option 1
+- option 2
+
+## Decision outcome
+
+What did we decide, and why? Stay at the level of the decision and its rationale —
+keep concrete values (subnets, IDs, ports, labels, tunables) in the issues and
+config, not here.
+
+### Consequences
+
+- Good — ...
+- Bad — ...
+- Note / follow-up — ...


### PR DESCRIPTION
## What

Restores only the MADR `0000-template.md` scaffolding wiped by the `A new start` reset.

The previously-decided ADRs (`0001`–`0003`, `0006`) are stale, so they are intentionally left out and will be re-authored fresh. The README index is likewise omitted (it would only reference stale records). `/new-adr` uses this template and will pick `0004` next.
