### PR TITLE
chore: scaffold target repo tree

### DIFF
--- a/ansible/inventories/README.md
+++ b/ansible/inventories/README.md
@@ -1,0 +1,4 @@
+# ansible/inventories/
+
+`prod/` holds this installation's inventory (`hosts.yml`) and `group_vars/`. Roles and
+playbooks stay generic and read their values from here.

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -1,0 +1,4 @@
+# ansible/playbooks/
+
+Entry-point playbooks composing roles against the active inventory. Planned: `site.yml`
+(everything), `routeros.yml`, `k3s.yml`, `homeassistant.yml`.

--- a/ansible/roles/README.md
+++ b/ansible/roles/README.md
@@ -1,0 +1,5 @@
+# ansible/roles/
+
+Generic, idempotent roles (second run = zero changes) — values come from the inventory. Planned: `node_baseline`,
+`k3s_server`, `k3s_agent`, `homeassistant`, `routeros_config` (community.routeros),
+`observability_agent`. Lint with `make lint-ansible`.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,6 @@
+# docs/runbooks/
+
+Operational, step-by-step procedures — written to be followed under stress, aviation
+quick-reference-handbook style (ordered steps, no reconstruction required). Planned:
+`bootstrap-sequence`, `disaster-recovery`, `move-checklist`, `restore-homeassistant`.
+The DR strategy behind them is ADR 0007.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,9 @@
+# kubernetes/
+
+GitOps root. The in-cluster controller reconciles this path and only this path (ADR 0001);
+infrastructure commits elsewhere in the repo are filtered out. Kept self-contained so a
+future public-facing cluster can be extracted to its own repository.
+
+- `clusters/prod/` — controller entrypoint (bootstrap + cluster-level kustomizations).
+- `infrastructure/` — platform services (ingress, cert-manager, storage, external-secrets, monitoring).
+- `apps/` — one directory per workload.

--- a/kubernetes/apps/README.md
+++ b/kubernetes/apps/README.md
@@ -1,0 +1,4 @@
+# kubernetes/apps/
+
+One directory per workload. Adding an app = adding a directory here and a kustomization
+reference from `clusters/prod/`.

--- a/kubernetes/clusters/prod/README.md
+++ b/kubernetes/clusters/prod/README.md
@@ -1,0 +1,5 @@
+# kubernetes/clusters/prod/
+
+The controller's entrypoint for the prod cluster: its bootstrap (`flux-system` once the
+delivery tool is decided in ADR 0004) and the top-level kustomizations that pull in
+`infrastructure/` and `apps/`.

--- a/kubernetes/infrastructure/README.md
+++ b/kubernetes/infrastructure/README.md
@@ -1,0 +1,5 @@
+# kubernetes/infrastructure/
+
+Platform services the apps depend on, delivered via the GitOps controller: ingress,
+cert-manager, storage, external-secrets (GCP Secret Manager sync), and `monitoring/`
+(kube-prometheus-stack + Loki + Alloy). Reconciled before `apps/`.

--- a/packer/k3s-proxmox/README.md
+++ b/packer/k3s-proxmox/README.md
@@ -1,0 +1,5 @@
+# packer/k3s-proxmox/
+
+Packer template for the k3s VM image on Proxmox (replaces the former hcloud MicroOS
+build). `make snapshot` builds it. See ADR 0003 (compute & workload placement) when it
+lands.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# scripts/
+
+Idempotent helpers invoked by the Makefile and runbooks (bootstrap, backup). Read values
+from the environment/inventory; never hard-code an installation's values.

--- a/terraform/environments/prod/README.md
+++ b/terraform/environments/prod/README.md
@@ -1,0 +1,6 @@
+# terraform/environments/prod/
+
+Root module for the prod environment — wires the modules together and holds this
+installation's values as tfvars (IPs, CIDRs, hostnames; secret *references*, not secrets).
+State in the GCS backend (`malachowski-state`, prefix `prod`). Run with `tofu` (not
+`terraform`); `make plan` / `make apply` target this directory.

--- a/terraform/modules/README.md
+++ b/terraform/modules/README.md
@@ -1,0 +1,8 @@
+# terraform/modules/
+
+Reusable OpenTofu modules. Map-driven where scale matters (add a node / VLAN / record =
+add a map entry). No hard-coded addresses — values arrive as variables; the environment
+root supplies this installation's values from its tfvars.
+
+Planned: `routeros-network`, `proxmox-node`, `k3s-vm`, `k3s-cluster`,
+`homeassistant-vm`, `dns-records`.


### PR DESCRIPTION
Scaffolds the skeleton from ADR 0001. Each directory carries a short README documenting its purpose.

This installation's values live next to what consumes them — `terraform/environments/prod` tfvars and `ansible/inventories/prod` — and modules/roles take values as inputs rather than hard-coding them.

Layout: `terraform/{modules,environments/prod}`, `ansible/{roles,playbooks,inventories}`, `packer/k3s-proxmox/`, `kubernetes/{,clusters/prod,infrastructure,apps}`, `docs/runbooks/`, `scripts/`.

Structure only — no modules, roles, or manifests yet. Values are filled in A3; Makefile/CI wiring in A4/A5.

Closes #209