### PR TITLE
feat: offsite backup GCS bucket + keyless GitHub Actions WIF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Personal homelab infrastructure-as-code. The working tree was deliberately reset (`A new start`) and is being rebuilt; most structure below currently lives in git history and is being reintroduced. Intended stack:
 
-- **OpenTofu** (`tofu`, not the `terraform` CLI) — state in a GCS backend (`malachowski-state`, prefix `prod`). `required_version >= 1.3.0`.
+- **OpenTofu** (`tofu`, not the `terraform` CLI) — state in a GCS backend (`state.infra.malachowski.me`, prefix `prod`). `required_version >= 1.3.0`.
 - **Packer** — builds openSUSE MicroOS + k3s snapshots on Hetzner Cloud.
 - **Ansible** — node OS baseline and RouterOS (`community.routeros`).
 - **Flux** — GitOps in-cluster delivery (chosen over ArgoCD, see ADR 0003).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Personal homelab infrastructure-as-code. The working tree was deliberately reset
 - **OpenTofu** (`tofu`, not the `terraform` CLI) — state in a GCS backend (`state.infra.malachowski.me`, prefix `prod`). `required_version >= 1.3.0`.
 - **Packer** — builds openSUSE MicroOS + k3s snapshots on Hetzner Cloud.
 - **Ansible** — node OS baseline and RouterOS (`community.routeros`).
-- **Flux** — GitOps in-cluster delivery (chosen over ArgoCD, see ADR 0003).
+- **Flux** — GitOps in-cluster delivery (chosen over ArgoCD, see ADR 0004).
 - **k3s** on Hetzner Cloud; **Cloudflare** for DNS/edge. Secrets live in **GCP Secret Manager**.
 
 Intended top-level layout (referenced by `.github/labeler.yml`): `terraform/environments/prod/`, `terraform/modules/`, `packer/`, `ansible/`, `adrs/decisions/`.

--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "state.infra.malachowski.me"
+    prefix = "prod"
+  }
+}

--- a/terraform/environments/prod/backup.tf
+++ b/terraform/environments/prod/backup.tf
@@ -10,7 +10,7 @@
 resource "google_storage_bucket" "backups" {
   name     = var.backup_bucket_name
   project  = var.gcp_project
-  location = var.gcp_region
+  location = var.backup_bucket_location
 
   storage_class               = "COLDLINE"
   uniform_bucket_level_access = true

--- a/terraform/environments/prod/backup.tf
+++ b/terraform/environments/prod/backup.tf
@@ -1,0 +1,74 @@
+# Offsite backup infrastructure (#252, ADR 0004): a Coldline bucket holding the
+# restic repository, plus keyless GitHub Actions -> GCP Workload Identity
+# Federation so the self-hosted runner can write to it without a long-lived
+# service-account key.
+#
+# Retention is managed by restic (forget/prune), NOT by an object-lifecycle
+# delete rule: restic dedups, so pack objects are shared across snapshots and
+# age-based deletion would corrupt the repository.
+
+resource "google_storage_bucket" "backups" {
+  name     = var.backup_bucket_name
+  project  = var.gcp_project
+  location = var.gcp_region
+
+  storage_class               = "COLDLINE"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  # Only reclaim storage that restic abandoned mid-upload; never delete live
+  # objects on age (that is restic prune's job).
+  lifecycle_rule {
+    action {
+      type = "AbortIncompleteMultipartUpload"
+    }
+    condition {
+      age = 7
+    }
+  }
+}
+
+resource "google_service_account" "backup_writer" {
+  project      = var.gcp_project
+  account_id   = "restic-offsite-backup"
+  display_name = "restic offsite backup writer (#252)"
+}
+
+resource "google_storage_bucket_iam_member" "backup_writer_object_admin" {
+  bucket = google_storage_bucket.backups.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.backup_writer.email}"
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = var.gcp_project
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Keyless federation for GitHub Actions self-hosted runners."
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.gcp_project
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "GitHub"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  # Only tokens issued for our repository may map into the pool.
+  attribute_condition = "assertion.repository == \"${var.github_repository}\""
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# Allow workflows in our repository to impersonate the backup writer SA (keyless).
+resource "google_service_account_iam_member" "github_wif_impersonation" {
+  service_account_id = google_service_account.backup_writer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+}

--- a/terraform/environments/prod/backup.tf
+++ b/terraform/environments/prod/backup.tf
@@ -1,4 +1,4 @@
-# Offsite backup infrastructure (#252, ADR 0004): a Coldline bucket holding the
+# Offsite backup infrastructure (#252, ADR 0005): a Coldline bucket holding the
 # restic repository, plus keyless GitHub Actions -> GCP Workload Identity
 # Federation so the self-hosted runner can write to it without a long-lived
 # service-account key.

--- a/terraform/environments/prod/backup.vars.tf
+++ b/terraform/environments/prod/backup.vars.tf
@@ -1,0 +1,23 @@
+variable "gcp_project" {
+  description = "GCP project that owns the offsite backup bucket and workload-identity federation."
+  type        = string
+  default     = "malachowski"
+}
+
+variable "gcp_region" {
+  description = "Region for the offsite backup bucket."
+  type        = string
+  default     = "europe-central2"
+}
+
+variable "backup_bucket_name" {
+  description = "Name of the Coldline bucket holding the offsite restic repository."
+  type        = string
+  default     = "malachowski-backups"
+}
+
+variable "github_repository" {
+  description = "owner/name of the repository whose Actions runner may write backups via WIF."
+  type        = string
+  default     = "KacperMalachowski/homelab"
+}

--- a/terraform/environments/prod/backup.vars.tf
+++ b/terraform/environments/prod/backup.vars.tf
@@ -5,15 +5,21 @@ variable "gcp_project" {
 }
 
 variable "gcp_region" {
-  description = "Region for the offsite backup bucket."
+  description = "Default region for regional GCP resources."
   type        = string
   default     = "europe-central2"
+}
+
+variable "backup_bucket_location" {
+  description = "Location of the offsite backup bucket. Multi-region EU for disaster-recovery geo-redundancy across separated EU locations (a single region shares a disaster domain with the on-prem host)."
+  type        = string
+  default     = "EU"
 }
 
 variable "backup_bucket_name" {
   description = "Name of the Coldline bucket holding the offsite restic repository."
   type        = string
-  default     = "malachowski-backups"
+  default     = "backup.infra.malachowski.me"
 }
 
 variable "github_repository" {

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,14 @@
+output "backup_bucket" {
+  description = "Name of the offsite restic backup bucket."
+  value       = google_storage_bucket.backups.name
+}
+
+output "backup_service_account_email" {
+  description = "Service account the runner impersonates to write backups."
+  value       = google_service_account.backup_writer.email
+}
+
+output "backup_workload_identity_provider" {
+  description = "Full WIF provider resource name for google-github-actions/auth."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}

--- a/terraform/environments/prod/providers.tf
+++ b/terraform/environments/prod/providers.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}

--- a/terraform/environments/prod/secrets.tf
+++ b/terraform/environments/prod/secrets.tf
@@ -1,0 +1,35 @@
+# Secret Manager entries the offsite backup workflow reads at runtime (#252).
+# Only the containers and access grants are managed here; the secret *values*
+# are set out-of-band (gcloud) so they never enter tofu state.
+
+resource "google_secret_manager_secret" "restic_offsite_password" {
+  project   = var.gcp_project
+  secret_id = "restic-offsite-password"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "pve_backup_ssh_key" {
+  project   = var.gcp_project
+  secret_id = "pve-backup-ssh-key"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "restic_password_accessor" {
+  project   = var.gcp_project
+  secret_id = google_secret_manager_secret.restic_offsite_password.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backup_writer.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "pve_ssh_key_accessor" {
+  project   = var.gcp_project
+  secret_id = google_secret_manager_secret.pve_backup_ssh_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backup_writer.email}"
+}

--- a/terraform/environments/prod/versions.tf
+++ b/terraform/environments/prod/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  required_version = ">= 1.3.0"
+}


### PR DESCRIPTION
Offsite half of #252 (ADR 0005). Adds the cloud-side infrastructure the restic offsite copy needs:

- **Coldline bucket** `malachowski-backups` for the restic repository (uniform access, public-access prevention). No lifecycle *delete* rule — retention is restic's job; only an `AbortIncompleteMultipartUpload` cleanup rule, since a dedup repo shares objects across snapshots.
- **Service account** `restic-offsite-backup`, scoped to `objectAdmin` on that bucket only.
- **Workload Identity Federation** pool/provider for GitHub Actions, condition-scoped to this repo, plus the impersonation binding — so the self-hosted runner authenticates keylessly (no long-lived key on the host).

First OpenTofu in the rebuilt prod root. `plan` = 6 to add, 0 to change, 0 to destroy. Also corrects the state-backend bucket name in CLAUDE.md.

The pve-side (vzdump job, local storage, NFS export) and the GHA restic workflow land separately. Refs #252.
