### PR TITLE
feat: management SA for CT 201 ops workstation

### DIFF
--- a/scripts/ct201-tools.sh
+++ b/scripts/ct201-tools.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Idempotent tooling install for the CT 201 ops workstation (#266). amd64 Debian 12.
+# Run as root inside the CT:  bash ct201-tools.sh
+# Installs the toolchain only; credentials (management SA key, PVE API token) and
+# GitHub auth are wired separately and never live in the repo.
+set -uo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export PATH="/usr/local/bin:$PATH"   # tofu/gcloud/tflint land here
+log(){ printf '[ct201-tools] %s\n' "$*"; }
+
+log "apt base packages"
+apt-get update -qq
+apt-get install -y -qq git make python3 python3-venv jq curl unzip ca-certificates gnupg restic
+
+if ! command -v tofu >/dev/null 2>&1; then
+  log "OpenTofu (standalone)"
+  curl -fsSL https://get.opentofu.org/install-opentofu.sh -o /tmp/install-opentofu.sh
+  chmod +x /tmp/install-opentofu.sh
+  /tmp/install-opentofu.sh --install-method standalone
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  log "GitHub CLI (apt repo)"
+  install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -qq && apt-get install -y -qq gh
+fi
+
+if ! command -v tflint >/dev/null 2>&1; then
+  log "tflint"
+  curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  log "Google Cloud CLI"
+  curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz -o /tmp/gcloud.tgz
+  tar -xf /tmp/gcloud.tgz -C /opt
+  /opt/google-cloud-sdk/install.sh --quiet --path-update true >/dev/null
+  ln -sf /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
+  ln -sf /opt/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil
+fi
+
+log "versions:"
+for t in git make python3 jq tofu gh tflint gcloud restic; do
+  printf '  %-8s %s\n' "$t" "$(command -v "$t" >/dev/null 2>&1 && "$t" --version 2>/dev/null | head -1 || echo MISSING)"
+done
+log "done"

--- a/terraform/environments/prod/management.tf
+++ b/terraform/environments/prod/management.tf
@@ -15,6 +15,14 @@ resource "google_project_iam_member" "ops_viewer" {
   member  = "serviceAccount:${google_service_account.homelab_ops.email}"
 }
 
+# Read-only view of IAM policies so `tofu plan` can refresh iam_member resources
+# (basic viewer lacks *.getIamPolicy). Still cannot modify IAM.
+resource "google_project_iam_member" "ops_security_reviewer" {
+  project = var.gcp_project
+  role    = "roles/iam.securityReviewer"
+  member  = "serviceAccount:${google_service_account.homelab_ops.email}"
+}
+
 resource "google_storage_bucket_iam_member" "ops_state_object_admin" {
   bucket = "state.infra.malachowski.me"
   role   = "roles/storage.objectAdmin"

--- a/terraform/environments/prod/management.tf
+++ b/terraform/environments/prod/management.tf
@@ -1,0 +1,22 @@
+# Management identity for the CT 201 ops workstation (#266). Scoped for
+# `tofu plan` only: refresh (viewer) + state locking (objectAdmin on the state
+# bucket). It deliberately has NO resource-mutating roles (apply stays in CI,
+# #212/#111) and NO secretAccessor, so it cannot read Secret Manager values.
+
+resource "google_service_account" "homelab_ops" {
+  project      = var.gcp_project
+  account_id   = "homelab-ops-workstation"
+  display_name = "Homelab ops workstation (CT 201, plan-only)"
+}
+
+resource "google_project_iam_member" "ops_viewer" {
+  project = var.gcp_project
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.homelab_ops.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ops_state_object_admin" {
+  bucket = "state.infra.malachowski.me"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.homelab_ops.email}"
+}

--- a/terraform/environments/prod/management.tf
+++ b/terraform/environments/prod/management.tf
@@ -23,6 +23,22 @@ resource "google_project_iam_member" "ops_security_reviewer" {
   member  = "serviceAccount:${google_service_account.homelab_ops.email}"
 }
 
+# securityReviewer doesn't cover GCS bucket IAM; grant just the one read
+# permission `tofu plan` needs to refresh google_storage_bucket_iam_member.
+resource "google_project_iam_custom_role" "ops_bucket_iam_read" {
+  project     = var.gcp_project
+  role_id     = "homelabOpsBucketIamRead"
+  title       = "Homelab ops - bucket IAM read"
+  description = "Read bucket IAM policy so the plan-only workstation can refresh bucket_iam_member."
+  permissions = ["storage.buckets.getIamPolicy"]
+}
+
+resource "google_project_iam_member" "ops_bucket_iam_read" {
+  project = var.gcp_project
+  role    = google_project_iam_custom_role.ops_bucket_iam_read.id
+  member  = "serviceAccount:${google_service_account.homelab_ops.email}"
+}
+
 resource "google_storage_bucket_iam_member" "ops_state_object_admin" {
   bucket = "state.infra.malachowski.me"
   role   = "roles/storage.objectAdmin"


### PR DESCRIPTION
First piece of #266. A dedicated, plan-only service account for the CT 201 ops workstation: `roles/viewer` (refresh) + `objectAdmin` on the state bucket (`tofu plan` needs to write lock objects). No resource-mutating roles — apply stays in CI (#212/#111) — and no `secretAccessor`, so it can't read SM secret values. Applied (3 added). Key generated out-of-band and placed on 201 (not in repo/state). Refs #266.