### PR TITLE
fix: offsite backup — sshfs zero-copy + weekly cadence (#252)

### DIFF
--- a/.github/workflows/backup-offsite.yml
+++ b/.github/workflows/backup-offsite.yml
@@ -102,9 +102,31 @@ jobs:
         run: |
           set -euo pipefail
           restic="$RUNNER_TEMP/bin/restic"
+          mnt="$RUNNER_TEMP/mnt"
           # Initialise the repo on first run only.
           "$restic" cat config >/dev/null 2>&1 || "$restic" init
-          "$restic" backup --host pve --tag vzdump "$RUNNER_TEMP/mnt"
+
+          # Offsite keeps a single weekly restore point, so capture only the
+          # newest image archive per guest (.vma.zst / .tar.zst) — never the
+          # .log/.notes sidecars or any in-progress temp files. The 7 nightly
+          # points live on the local copy for fine-grained restore; re-uploading
+          # all of them weekly would read ~7x more over sshfs and, since
+          # zstd images barely dedup across nights, write ~7x more to GCS.
+          shopt -s nullglob
+          declare -A newest
+          for f in "$mnt"/vzdump-*.vma.zst "$mnt"/vzdump-*.tar.zst; do
+            key=$(basename "$f"); key=${key%-20*}   # vzdump-<type>-<vmid>
+            if [ -z "${newest[$key]:-}" ] || [ "$f" -nt "${newest[$key]}" ]; then
+              newest[$key]="$f"
+            fi
+          done
+          targets=("${newest[@]}")
+          if [ ${#targets[@]} -eq 0 ]; then
+            echo "::error::no vzdump archives found under $mnt"; exit 1
+          fi
+          printf 'backing up: %s\n' "${targets[@]}"
+
+          "$restic" backup --host pve --tag vzdump "${targets[@]}"
           # Prune every run so space is always reclaimed. Retention is tuned for
           # the weekly cadence (a daily tier is meaningless at one snapshot/week):
           # keep the last 6 weeks plus 6 monthlies of restore points.

--- a/.github/workflows/backup-offsite.yml
+++ b/.github/workflows/backup-offsite.yml
@@ -1,15 +1,20 @@
 name: Offsite backup (restic → GCS)
 
-# Pulls the nightly Proxmox vzdump archives off the pve host (read-only, over an
-# rrsync-pinned SSH key) and pushes an encrypted, deduplicated copy to the
-# multi-region EU Coldline bucket via restic. Runs on the self-hosted mgmt
-# runner and authenticates to GCP keylessly through Workload Identity Federation
-# — no long-lived key on the host. Secrets (restic password, pull SSH key) come
-# from GCP Secret Manager at runtime. See ADR 0005 / #252.
+# Mounts the nightly Proxmox vzdump dir off the pve host read-only over sshfs
+# (SFTP-pinned key) and streams it straight into restic — no local staging, so
+# the runner's small disk never holds a copy of the archives. restic pushes an
+# encrypted, deduplicated copy to the multi-region EU Coldline bucket. Runs on
+# the self-hosted mgmt runner and authenticates to GCP keylessly through Workload
+# Identity Federation — no long-lived key on the host. Secrets (restic password,
+# pull SSH key) come from GCP Secret Manager at runtime. See ADR 0004 / #252.
 
 on:
   schedule:
-    - cron: "30 2 * * *" # after the 02:00 local vzdump job (UTC; ~03:30–04:30 local)
+    # Weekly, not nightly: the offsite push's dominant cost is bytes written to a
+    # multi-region bucket (cross-region replication transfer), so cadence drives
+    # spend more than anything else. Local vzdump stays nightly, so on-box
+    # recovery is unaffected; only the offsite DR copy's RPO relaxes to ~1 week.
+    - cron: "30 2 * * 0" # Sunday, after the 02:00 local vzdump (UTC; ~04:30 local)
   workflow_dispatch: {}
 
 concurrency:
@@ -55,7 +60,7 @@ jobs:
           SSH_KEY: ${{ steps.secrets.outputs.ssh_key }}
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/bin" "$RUNNER_TEMP/stage"
+          mkdir -p "$RUNNER_TEMP/bin" "$RUNNER_TEMP/mnt"
           # RUNNER_TEMP is recreated per job, so fetch restic each run (there is no
           # binary to cache across runs here).
           url="https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_arm64.bz2"
@@ -65,36 +70,53 @@ jobs:
           chmod +x "$RUNNER_TEMP/bin/restic"
           "$RUNNER_TEMP/bin/restic" version
 
-          # Pinned pull key (read-only, rrsync-confined on the pve side).
+          # Pinned pull key (read-only SFTP forced-command on the pve side).
           umask 077
           printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/pull_key"
           chmod 600 "$RUNNER_TEMP/pull_key"
 
-      - name: Pull vzdump archives from pve (read-only)
+      - name: Mount pve dump dir (read-only, sshfs)
         run: |
           set -euo pipefail
-          rsync -a --info=stats1 \
-            -e "ssh -i '$RUNNER_TEMP/pull_key' -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15" \
-            "${PVE_DUMP_USER}@${PVE_HOST}:./" "$RUNNER_TEMP/stage/"
-          ls -lh "$RUNNER_TEMP/stage"
+          command -v sshfs >/dev/null || {
+            echo "::error::sshfs is not installed on the runner (apt-get install sshfs)"; exit 1;
+          }
+          # Zero-copy: restic reads the archives straight off the mount, so the
+          # runner never stages a local copy (a full pull overran its disk).
+          # -o compression=no: the .vma.zst are already compressed, don't burn
+          # Pi CPU re-compressing the SFTP stream.
+          sshfs "${PVE_DUMP_USER}@${PVE_HOST}:/mnt/pve/backup-local/dump" "$RUNNER_TEMP/mnt" \
+            -o IdentityFile="$RUNNER_TEMP/pull_key" \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            -o ro -o reconnect -o ConnectTimeout=15 -o compression=no
+          ls -lh "$RUNNER_TEMP/mnt"
 
       - name: Push to GCS with restic
         env:
           RESTIC_PASSWORD: ${{ steps.secrets.outputs.restic_password }}
           GOOGLE_PROJECT_ID: malachowski
+          # Keep restic's cache inside RUNNER_TEMP so it stays ephemeral and can
+          # never accumulate on the runner's small disk. It holds only repo
+          # index/metadata (tens of MB), never archive data.
+          RESTIC_CACHE_DIR: ${{ runner.temp }}/restic-cache
         run: |
           set -euo pipefail
           restic="$RUNNER_TEMP/bin/restic"
           # Initialise the repo on first run only.
           "$restic" cat config >/dev/null 2>&1 || "$restic" init
-          "$restic" backup --host pve --tag vzdump "$RUNNER_TEMP/stage"
-          # Prune every run so space is always reclaimed. A fixed-weekday prune
-          # could be skipped for weeks if the runner is offline that day, leaving
-          # the repo to grow; the Coldline early-delete cost at this churn is
-          # negligible next to that risk.
-          "$restic" forget --keep-daily 7 --keep-weekly 4 --keep-monthly 6 --prune
+          "$restic" backup --host pve --tag vzdump "$RUNNER_TEMP/mnt"
+          # Prune every run so space is always reclaimed. Retention is tuned for
+          # the weekly cadence (a daily tier is meaningless at one snapshot/week):
+          # keep the last 6 weeks plus 6 monthlies of restore points.
+          "$restic" forget --keep-weekly 6 --keep-monthly 6 --prune
           "$restic" snapshots --compact
 
-      - name: Cleanup
+      - name: Unmount and cleanup
         if: always()
-        run: rm -rf "$RUNNER_TEMP/stage" "$RUNNER_TEMP/pull_key"
+        run: |
+          # Guaranteed teardown: plain unmount, then fuse3's binary, then a lazy
+          # unmount if restic was killed holding the mount busy.
+          fusermount -u "$RUNNER_TEMP/mnt" 2>/dev/null \
+            || fusermount3 -u "$RUNNER_TEMP/mnt" 2>/dev/null \
+            || fusermount -uz "$RUNNER_TEMP/mnt" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/pull_key"

--- a/.github/workflows/backup-offsite.yml
+++ b/.github/workflows/backup-offsite.yml
@@ -130,7 +130,13 @@ jobs:
           # Prune every run so space is always reclaimed. Retention is tuned for
           # the weekly cadence (a daily tier is meaningless at one snapshot/week):
           # keep the last 6 weeks plus 6 monthlies of restore points.
-          "$restic" forget --keep-weekly 6 --keep-monthly 6 --prune
+          #
+          # --group-by host,tags is load-bearing: the backup targets are the
+          # date-stamped archive paths, so each week's snapshot has unique paths.
+          # forget's default (group-by host,paths) would isolate every run into
+          # its own group and never prune — retention would grow without bound.
+          "$restic" forget --host pve --tag vzdump --group-by host,tags \
+            --keep-weekly 6 --keep-monthly 6 --prune
           "$restic" snapshots --compact
 
       - name: Unmount and cleanup

--- a/scripts/pve-backup-setup.sh
+++ b/scripts/pve-backup-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Codifies the pve-host side of the tested-offsite-backups work (#252, ADR 0005).
+# Codifies the pve-host side of the tested-offsite-backups work (#252, ADR 0004).
 # Idempotent: safe to re-run. Run as root ON the Proxmox host (pve):
 #
 #     scp scripts/pve-backup-setup.sh root@pve:/tmp/ && ssh root@pve bash /tmp/pve-backup-setup.sh
@@ -8,10 +8,10 @@
 # What it sets up:
 #   1. A dedicated ext4 backup volume on the idle 1TB HDD pool -> PVE `dir` storage.
 #   2. A nightly vzdump job (snapshot mode) with local retention.
-#   3. A PVE-privilege-free OS account `backup-ro` whose SSH key is pinned, via
-#      rrsync, to read-only access of the dump directory — this is what the
-#      offsite GitHub Actions workflow pulls with (its private key lives in GCP
-#      Secret Manager: `pve-backup-ssh-key`).
+#   3. A PVE-privilege-free OS account `backup-ro` whose SSH key is pinned to a
+#      read-only SFTP server — this is what the offsite GitHub Actions workflow
+#      mounts (sshfs, zero local copy) to feed restic (its private key lives in
+#      GCP Secret Manager: `pve-backup-ssh-key`).
 #
 # It intentionally does NOT touch guests or existing storage. The offsite push
 # (restic -> GCS, keyless WIF) lives in .github/workflows/backup-offsite.yml.
@@ -29,6 +29,7 @@ SCHEDULE="02:00"
 PRUNE="keep-daily=7,keep-weekly=4"
 JOB_MARKER="managed-by:pve-backup-setup"
 BACKUP_USER="backup-ro"
+SFTP_SERVER="/usr/lib/openssh/sftp-server"   # Debian/Proxmox path; the offsite pull key is pinned to it
 # Public half of the offsite pull key; private half is in GCP SM pve-backup-ssh-key.
 PULL_PUBKEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIObT5YPhI8eKuBtxTotu5y2jvWUaznBM5rWCTN03ODTf pve-backup-ro-pull"
 # -----------------------------------------------------------------------------
@@ -89,9 +90,12 @@ id "$BACKUP_USER" >/dev/null 2>&1 || {
   useradd -r -m -d "/home/$BACKUP_USER" -s /bin/bash "$BACKUP_USER"
 }
 install -d -m 700 -o "$BACKUP_USER" -g "$BACKUP_USER" "/home/$BACKUP_USER/.ssh"
-# Pin the key to rrsync, read-only, confined to the dump dir — nothing else.
-printf 'command="/usr/bin/rrsync -ro %s/dump",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding %s\n' \
-  "$MOUNT" "$PULL_PUBKEY" >"/home/$BACKUP_USER/.ssh/authorized_keys"
+# Pin the key to a read-only SFTP server. The offsite workflow mounts the dump
+# dir over sshfs and streams it straight into restic (no local staging), so the
+# runner's disk never holds a copy. `-R` forbids any write from the client; the
+# key already carries no PVE privileges and no interactive shell.
+printf 'command="%s -R",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding %s\n' \
+  "$SFTP_SERVER" "$PULL_PUBKEY" >"/home/$BACKUP_USER/.ssh/authorized_keys"
 chown "$BACKUP_USER:$BACKUP_USER" "/home/$BACKUP_USER/.ssh/authorized_keys"
 chmod 600 "/home/$BACKUP_USER/.ssh/authorized_keys"
 


### PR DESCRIPTION
## Why

The nightly offsite backup ([run 29552957045](https://github.com/KacperMalachowski/homelab/actions/runs/29552957045)) **OOM'd the rpi5 runner on disk** — it rsync'd the whole vzdump set into a local stage dir before restic read anything, and honeycomb (23 GB free) hit 0 MB mid-file staging the 24 GB set (`No space left on device`).

## What changed

**1. Zero-copy transport (fixes the OOM).** Mount the pve dump dir read-only over **sshfs** and point restic at the mount — the runner never stages a local copy; disk peak is just restic's metadata cache (pinned in `RUNNER_TEMP`).
- pve-side: pull key's forced command `rrsync -ro` → `sftp-server -R` (rrsync blocks the SFTP subsystem sshfs needs). **Same key/secret — no Terraform change.**
- Guaranteed unmount on failure (`fusermount -u` → `fusermount3 -u` → lazy `-uz`).

**2. Weekly cadence (cost).** The real SKU breakdown showed the dominant cost (**64%**) is **multi-region cross-region replication transfer**, which scales with *bytes written* — not storage class (Coldline early-delete was zł0.00). So nightly → weekly. Local vzdump stays nightly; only the offsite DR RPO relaxes to ~1 week.

**3. Newest-per-guest, image-only (speed + cost).** A weekly run over the whole dir would re-read all ~7 retained nightlies (~20 GiB, ~1 h over sshfs) and, since zstd images barely dedup across nights, re-upload ~7× to GCS. Instead, back up only the **newest `.vma.zst`/`.tar.zst` per guest** — skip `.log`/`.notes`/temp. Weekly read/write drops to ~3 GiB.

**4. Retention grouping fix.** Backup targets are date-stamped paths, so each week's snapshot has unique paths; `restic forget`'s default `--group-by host,paths` would isolate every run and never prune. Group by `host,tags` so `keep-weekly 6 --keep-monthly 6` spans all vzdump snapshots.

## Verified end-to-end on the live runner

All via `workflow_dispatch` on this branch, honeycomb + pve:
- ✅ WIF auth → secrets → **sshfs mount** → restic → unmount, **green** (no disk failure).
- ✅ Selects exactly the 2 newest archives (qemu-100 `.vma.zst` + lxc-101 `.tar.zst`); skips sidecars/tmp.
- ✅ Steady-state run: **2 files, 2.97 GiB, ~1 min**.
- ✅ `forget` prunes correctly: collapsed duplicate snapshots, reclaimed 12 GiB, left one snapshot/week.

pve forced-command swap applied (via `scripts/pve-backup-setup.sh`); `sshfs` installed on honeycomb.

## Note

The **nightly** cron on `main` (old rsync workflow) will keep failing until this merges — merging both fixes the OOM and switches to weekly.

## Follow-up (separate)

Bigger cost lever: move the bucket **multi-region EU → single region** (e.g. `europe-central2`), eliminating the replication SKU entirely (64%). Needs a bucket recreate (location immutable) + restic repo migration.

Refs #252, ADR 0004.