### PR TITLE
feat: move offsite restic bucket to a single EU region (#252)

### DIFF
--- a/.github/workflows/backup-offsite.yml
+++ b/.github/workflows/backup-offsite.yml
@@ -3,7 +3,7 @@ name: Offsite backup (restic → GCS)
 # Mounts the nightly Proxmox vzdump dir off the pve host read-only over sshfs
 # (SFTP-pinned key) and streams it straight into restic — no local staging, so
 # the runner's small disk never holds a copy of the archives. restic pushes an
-# encrypted, deduplicated copy to the multi-region EU Coldline bucket. Runs on
+# encrypted, deduplicated copy to the single-region EU Coldline bucket. Runs on
 # the self-hosted mgmt runner and authenticates to GCP keylessly through Workload
 # Identity Federation — no long-lived key on the host. Secrets (restic password,
 # pull SSH key) come from GCP Secret Manager at runtime. See ADR 0004 / #252.
@@ -32,7 +32,7 @@ env:
   RESTIC_VERSION: "0.17.3"
   # SHA256 of restic_${RESTIC_VERSION}_linux_arm64.bz2 (restic release SHA256SUMS).
   RESTIC_SHA256: "db27b803534d301cef30577468cf61cb2e242165b8cd6d8cd6efd7001be2e557"
-  RESTIC_REPOSITORY: "gs:backup.infra.malachowski.me:/pve"
+  RESTIC_REPOSITORY: "gs:offsite.infra.malachowski.me:/pve"
 
 jobs:
   offsite:

--- a/docs/runbooks/offsite-bucket-single-region-migration.md
+++ b/docs/runbooks/offsite-bucket-single-region-migration.md
@@ -1,0 +1,161 @@
+# Runbook: migrate the offsite restic bucket to a single region
+
+Moves the offsite backup repository off the **EU multi-region** Coldline bucket
+onto a **single EU region** (`europe-west1`) one, to drop the cross-region
+replication transfer the multi-region tier bills on every written byte. Refs
+#252, ADR 0004.
+
+## Why this is a runbook, not a `tofu apply`
+
+A bucket's `location` and `name` are immutable — Terraform would **destroy and
+recreate** the bucket, taking the restic repository with it. GCS in-place
+relocation is not an option here (it requires a paid Storage Intelligence
+subscription in both locations). So this is a **copy-and-cutover**: stand up a
+new bucket beside the old one, copy the repository, repoint the workflow,
+verify, then delete the old bucket. The old bucket is untouched until the very
+last step, so rollback is trivial.
+
+## Cost reality check (read before doing this)
+
+The big "64% of the bill" replication figure predates the newest-per-guest
+change, which already cut weekly writes ~85% (~20 GiB → ~3 GiB). The residual
+replication is now ~small change per month, versus a **one-time copy cost of
+~$1–2** (Coldline retrieval on the old bucket + early-delete when it is
+deleted). This migration is now **hygiene, not savings** — payback is months.
+Do it for correctness, not to move the needle on the bill.
+
+## Preconditions
+
+- The sshfs / weekly / newest-per-guest workflow (PR #278) is merged and a run
+  is green on `main`.
+- `gcloud` authenticated against project `malachowski` with rights to create
+  buckets, set IAM, and read the restic password secret.
+- The new bucket name is a dotted (domain-style) name under an already
+  domain-verified zone (`*.infra.malachowski.me`), so no new verification.
+
+Names/locations used below (match `terraform/environments/prod/backup.vars.tf`):
+
+| | value |
+|---|---|
+| old bucket | `gs://backup.infra.malachowski.me` (EU multi-region) |
+| new bucket | `gs://offsite.infra.malachowski.me` (`europe-west1`) |
+| repo path | `/pve` (unchanged) |
+| writer SA | `restic-offsite-backup@malachowski.iam.gserviceaccount.com` |
+
+> Region choice: `europe-west1` (Belgium) is geographically separated from the
+> Poland on-prem host — the right disaster domain for a DR copy — and among the
+> cheapest EU regions. Use `europe-central2` (Warsaw) instead only if data
+> residency in Poland outweighs DR separation; it is co-located with the primary.
+
+## Procedure
+
+### 1. (optional) Shrink the repo before copying
+
+Copy cost scales with repo size. If the repo still carries oversized
+whole-directory test snapshots, forget them first so the copy moves only live
+data:
+
+```sh
+export RESTIC_REPOSITORY="gs:backup.infra.malachowski.me:/pve"
+export RESTIC_PASSWORD="$(gcloud secrets versions access latest --secret=restic-offsite-password)"
+restic snapshots --compact
+restic forget <oversized-snapshot-ids> --prune
+```
+
+### 2. Create the new bucket (working-first)
+
+Mirror every setting Terraform will later assert, so the eventual `import`
+produces a clean plan:
+
+```sh
+gcloud storage buckets create gs://offsite.infra.malachowski.me \
+  --project=malachowski \
+  --location=europe-west1 \
+  --default-storage-class=COLDLINE \
+  --uniform-bucket-level-access \
+  --public-access-prevention=enforced
+
+# AbortIncompleteMultipartUpload after 7 days (matches backup.tf lifecycle_rule)
+printf '{"rule":[{"action":{"type":"AbortIncompleteMultipartUpload"},"condition":{"age":7}}]}' \
+  | gcloud storage buckets update gs://offsite.infra.malachowski.me --lifecycle-file=/dev/stdin
+
+# Writer SA needs objectAdmin (matches the google_storage_bucket_iam_member)
+gcloud storage buckets add-iam-policy-binding gs://offsite.infra.malachowski.me \
+  --member="serviceAccount:restic-offsite-backup@malachowski.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+### 3. Copy the repository
+
+Raw object copy preserves the restic repo exactly (same packs, index, keys) — no
+re-encryption, no re-init. restic identifies a repo by its objects, not the
+bucket name.
+
+```sh
+gcloud storage rsync -r \
+  gs://backup.infra.malachowski.me/pve \
+  gs://offsite.infra.malachowski.me/pve
+```
+
+### 4. Verify the new repo before cutover
+
+```sh
+export RESTIC_REPOSITORY="gs:offsite.infra.malachowski.me:/pve"
+export RESTIC_PASSWORD="$(gcloud secrets versions access latest --secret=restic-offsite-password)"
+restic snapshots --compact     # same snapshots as the old repo
+restic check                   # structural integrity of the copy
+```
+
+Do **not** proceed unless `check` is clean.
+
+### 5. Cut over
+
+Merge this PR (workflow `RESTIC_REPOSITORY` and tofu vars now point at the new
+bucket), then prove the live path against the new bucket:
+
+```sh
+gh workflow run backup-offsite.yml --ref main
+gh run watch <run-id> --exit-status
+```
+
+A green run writes a fresh snapshot to the new bucket. If it fails, **roll back**
+by reverting the `RESTIC_REPOSITORY` change — the old bucket is still intact and
+current.
+
+### 6. Reconcile Terraform state (no destroy/recreate)
+
+`google_storage_bucket.backups` still points state at the old bucket. Adopt the
+hand-created new bucket so `apply` is a no-op instead of a destroy+create:
+
+```sh
+cd terraform/environments/prod
+tofu state rm google_storage_bucket.backups
+tofu import google_storage_bucket.backups offsite.infra.malachowski.me
+tofu plan   # expect: no changes to the bucket (IAM/lifecycle already match)
+```
+
+### 7. Delete the old bucket
+
+Only after at least one green run against the new bucket and a verified
+`restic check`:
+
+```sh
+gcloud storage rm -r gs://backup.infra.malachowski.me/**
+gcloud storage buckets delete gs://backup.infra.malachowski.me
+```
+
+Deleting Coldline objects younger than 90 days incurs a one-time early-delete
+charge — expected and small.
+
+## Rollback
+
+At any point before step 7, revert `RESTIC_REPOSITORY` (and, if state was
+already reconciled, re-import the old bucket). No data is lost: the old bucket is
+only removed in the final step.
+
+## Post-migration
+
+- Confirm the next scheduled weekly run is green against the new bucket.
+- Re-affirm ADR 0004's acceptance test: a `restic restore` from the new bucket
+  into a scratch target.
+- Mirror of the restic password in KeePass is unchanged (same secret).

--- a/terraform/environments/prod/backup.tf
+++ b/terraform/environments/prod/backup.tf
@@ -1,7 +1,13 @@
-# Offsite backup infrastructure (#252, ADR 0005): a Coldline bucket holding the
-# restic repository, plus keyless GitHub Actions -> GCP Workload Identity
-# Federation so the self-hosted runner can write to it without a long-lived
-# service-account key.
+# Offsite backup infrastructure (#252, ADR 0004): a single-region Coldline
+# bucket holding the restic repository, plus keyless GitHub Actions -> GCP
+# Workload Identity Federation so the self-hosted runner can write to it without
+# a long-lived service-account key.
+#
+# Location is a single EU region, not EU multi-region: the multi-region tier
+# bills cross-region replication transfer per written byte (the top line on the
+# backup bill), which an offsite DR copy does not need on top of single-region's
+# 11-nines durability. Migrating an existing bucket is a copy-and-cutover, not an
+# in-place apply -> docs/runbooks/offsite-bucket-single-region-migration.md.
 #
 # Retention is managed by restic (forget/prune), NOT by an object-lifecycle
 # delete rule: restic dedups, so pack objects are shared across snapshots and

--- a/terraform/environments/prod/backup.vars.tf
+++ b/terraform/environments/prod/backup.vars.tf
@@ -11,15 +11,15 @@ variable "gcp_region" {
 }
 
 variable "backup_bucket_location" {
-  description = "Location of the offsite backup bucket. Multi-region EU for disaster-recovery geo-redundancy across separated EU locations (a single region shares a disaster domain with the on-prem host)."
+  description = "Location of the offsite backup bucket. Single EU region (europe-west1, geographically separated from the Poland on-prem host) rather than EU multi-region: the multi-region tier bills cross-region replication transfer on every written byte — the largest line on the backup bill — for geo-redundancy an offsite DR copy does not need on top of single-region's 11-nines durability. See docs/runbooks/offsite-bucket-single-region-migration.md."
   type        = string
-  default     = "EU"
+  default     = "europe-west1"
 }
 
 variable "backup_bucket_name" {
-  description = "Name of the Coldline bucket holding the offsite restic repository."
+  description = "Name of the Coldline bucket holding the offsite restic repository. Region-neutral name so a future relocation never forces another rename."
   type        = string
-  default     = "backup.infra.malachowski.me"
+  default     = "offsite.infra.malachowski.me"
 }
 
 variable "github_repository" {


### PR DESCRIPTION
**Stacked on #278** (base = `fix/252-offsite-sshfs-weekly`). Merge #278 first; this retargets to `main` after.

## Why

The offsite bucket is **EU multi-region**, whose tier bills **cross-region replication transfer on every written byte** — historically the top line on the backup bill. An offsite DR copy doesn't need multi-region geo-redundancy on top of single-region's 11-nines durability, so move to a **single EU region** (`europe-west1`, geographically separated from the Poland on-prem host).

## ⚖️ Honest cost reassessment (please read)

The "64% of the bill" replication figure was true **before** the newest-per-guest change in #278, which already cut weekly writes ~85% (~20 GiB → ~3 GiB). Residual replication is now small change/month, against a **one-time ~$1–2 copy cost**. This is now **hygiene, not savings** — payback is months. Landing it for correctness; flagging so you can decide whether it's worth executing now or parking the runbook until later.

## What's in the PR

- **`backup.vars.tf`** — `backup_bucket_location` `EU` → `europe-west1`; `backup_bucket_name` → `offsite.infra.malachowski.me` (region-neutral, so a future move never forces another rename).
- **`backup.tf`** — header rationale updated; storage class stays `COLDLINE`.
- **`backup-offsite.yml`** — `RESTIC_REPOSITORY` → new bucket.
- **`docs/runbooks/offsite-bucket-single-region-migration.md`** — the actual migration procedure.

## Why a runbook, not an apply

`location`/`name` are immutable → a naive `apply` would **destroy+recreate** the bucket and take the restic repo with it. GCS in-place relocation needs a **paid Storage Intelligence** subscription (verified: HTTP 412), so it's a **copy-and-cutover**: new bucket → `gcloud storage rsync` the repo → `restic check` → repoint → reconcile tofu state (`state rm` + `import`, no destroy) → delete old. **Old bucket is untouched until the last step; rollback is reverting one env var.**

## Region note

`europe-west1` (Belgium) = DR separation from the Poland primary + cheap. `europe-central2` (Warsaw) only if data residency outweighs DR separation (it's co-located with the primary).

Refs #252, ADR 0004.